### PR TITLE
🎨 Palette: Restore focus after closing modals for keyboard navigation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-05-18 - Added loading state feedback to async checkout button
 **Learning:** For user actions that trigger asynchronous operations (like API calls or opening checkouts), providing immediate visual feedback is crucial to prevent multiple submissions and communicate that the application is working. While doing this in vanilla JS, modifying `.innerHTML` to inject a loading spinner and restoring the original HTML afterwards is an effective way to preserve inner icons or styling. Furthermore, modifying the `disabled` state, setting `aria-busy="true"`, and changing the cursor to `wait` are simple yet vital additions to ensure robust UX and accessibility during the loading phase.
 **Action:** Always provide loading states for async actions. In vanilla JS contexts, carefully stash and restore original element markup when modifying it, and remember to include ARIA attributes like `aria-busy="true"` alongside native `disabled` states for accessibility.
+
+## 2024-05-18 - Restored focus after closing modals for keyboard navigation
+**Learning:** Custom modals disrupt keyboard navigation by failing to return focus to the element that triggered the modal. This creates a frustrating experience where closing a dialog resets the user's tab order back to the top of the document.
+**Action:** When implementing custom modals and lightboxes, always cache the `document.activeElement` before the modal opens and explicitly call `.focus()` on the cached element when the modal is closed to preserve the navigation flow.

--- a/index.html
+++ b/index.html
@@ -2582,15 +2582,18 @@
       };
 
       let activeRoomForCheckout = null;
+      let activeElementBeforeModal = null;
       const roomModal = document.getElementById('roomModal');
 
       let currentLightboxImages = [];
       let currentLightboxIndex = 0;
+      let activeElementBeforeLightbox = null;
       const lightbox = document.getElementById('lightbox');
       const lightboxImg = document.getElementById('lightboxImg');
       const lightboxCounter = document.getElementById('lightboxCounter');
 
       function openLightbox(images, startIndex) {
+        activeElementBeforeLightbox = document.activeElement;
         currentLightboxImages = images;
         currentLightboxIndex = startIndex || 0;
         updateLightbox();
@@ -2605,6 +2608,9 @@
 
       function closeLightbox() {
         lightbox.classList.remove('active');
+        if (activeElementBeforeLightbox) {
+          activeElementBeforeLightbox.focus();
+        }
       }
 
       function lightboxPrevImage() {
@@ -2626,6 +2632,7 @@
         const data = ROOM_DATA[roomName];
         if (!data) return;
 
+        activeElementBeforeModal = document.activeElement;
         activeRoomForCheckout = roomName;
         document.getElementById('modalTitle').textContent = roomName;
         document.getElementById('modalPrice').textContent = data.price;
@@ -2692,6 +2699,9 @@
         // Restore demo banner
         const banner = document.getElementById('demoBanner');
         if (banner) banner.style.zIndex = '200';
+        if (activeElementBeforeModal) {
+          activeElementBeforeModal.focus();
+        }
       }
 
       // View All Photos button
@@ -2720,9 +2730,17 @@
 
         // Make the whole card clickable for the premium feel
         card.style.cursor = 'pointer';
+        card.tabIndex = 0;
         card.addEventListener('click', (e) => {
           e.preventDefault();
           openRoomModal(roomName);
+        });
+
+        card.addEventListener('keydown', (e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            openRoomModal(roomName);
+          }
         });
 
         // Also ensure button clicks open modal and don't bubble


### PR DESCRIPTION
## 💡 What
Added keyboard focus management to preserve the user's place on the page when opening and closing modals or lightboxes. Additionally, made `.room-card` elements keyboard-focusable and interactable via 'Enter' and 'Space' keys.

## 🎯 Why
When a screen reader or keyboard-only user interacts with a modal (like a gallery lightbox or a room details modal), closing that modal currently resets their focus, often throwing them back to the top of the document. This creates a frustrating and disorienting experience. By caching `document.activeElement` before the modal opens and calling `.focus()` on it when the modal closes, we preserve the user's natural navigation flow. Making `.room-card` focusable is a prerequisite to allow keyboard users to open the room modals in the first place.

## 📸 Before/After
**Before:** Clicking a room card or gallery image via mouse opened a modal, but keyboard users could not tab to room cards. Closing a modal left the focus undefined (usually resetting to the document body).
**After:** Keyboard users can Tab to `.room-card` elements and press Enter/Space to open them. Closing the room modal or image lightbox instantly returns focus to the exact card or image that opened it.

## ♿ Accessibility
- Added `tabindex="0"` to `.room-card` elements to make them focusable in the document flow.
- Added `keydown` event listeners to trigger click actions on `.room-card` elements using `Enter` (key code 13) or `Space` (key code 32).
- Implemented `document.activeElement` caching (`activeElementBeforeModal` and `activeElementBeforeLightbox`) to safely restore focus after closing custom modals/lightboxes, ensuring WCAG compliance for focus management.

---
*PR created automatically by Jules for task [18431951842988104331](https://jules.google.com/task/18431951842988104331) started by @sr-sov*